### PR TITLE
Laravel 10 compatibility

### DIFF
--- a/src/Models/FailedJob.php
+++ b/src/Models/FailedJob.php
@@ -16,10 +16,7 @@ class FailedJob extends \Illuminate\Database\Eloquent\Model
 
     protected $casts = [
         'payload' => 'array',
-    ];
-
-    protected $dates = [
-        'failed_at',
+        'failed_at' => 'datetime',
     ];
 
     public $timestamps = false;


### PR DESCRIPTION
Changed the `FailedJob` model so the `failed_at` column doesn't use the in Laravel 10 removed `$dates` property anymore but casts it to datetime.